### PR TITLE
Fix shop entity nullable

### DIFF
--- a/src/Entity/Shop.php
+++ b/src/Entity/Shop.php
@@ -9,12 +9,12 @@ use Shopware\AppBundle\Entity\AbstractShop;
 #[Entity]
 class Shop extends AbstractShop
 {
-    #[Column(type: 'string')]
+    #[Column(type: 'string', nullable: true)]
     public ?string $shopVersion = null;
 
-    #[Column(type: 'string')]
+    #[Column(type: 'string', nullable: true)]
     public ?string $selectedAppVersion = null;
 
-    #[Column(type: 'string')]
+    #[Column(type: 'string', nullable: true)]
     public ?string $selectedAppHash = null;
 }


### PR DESCRIPTION
Shop entity should has a Default NULL for migration schema database, avoid NOT null exception

EX: selected_app_hash VARCHAR(255) DEFAULT NULL