### PR TITLE
Allow to check and uninstall apps

### DIFF
--- a/src/App/AppSelector.php
+++ b/src/App/AppSelector.php
@@ -41,6 +41,17 @@ class AppSelector
         throw NoSupportedAppException::fromAppVersion($appVersion);
     }
 
+    public function hasVersion(string $appVersion): bool
+    {
+        foreach ($this->appLoader->load() as $app) {
+            if ($app->version === $appVersion) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return array<App>
      */

--- a/src/Command/CanCleanupVersionCommand.php
+++ b/src/Command/CanCleanupVersionCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Shopware\ServiceBundle\Command;
+
+use Shopware\ServiceBundle\App\AppSelector;
+use Shopware\ServiceBundle\ShopRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'services:can-cleanup-version',
+    description: 'Checks if any shops are still running on a given version.',
+)]
+class CanCleanupVersionCommand extends Command
+{
+    public function __construct(
+        private ShopRepository $repository,
+        private readonly AppSelector $appSelector,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'The version to query.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $version = $input->getArgument('version');
+        assert(is_string($version));
+
+        if (!$this->appSelector->hasVersion($version)) {
+            $io->error(sprintf('Version "%s" does not exist', $version));
+            return Command::FAILURE;
+        }
+
+        $shopIds = [];
+        foreach ($this->repository->findActiveShopsForVersion($version) as $shop) {
+            $shopIds[] = $shop->getShopId();
+        }
+
+        if (empty($shopIds)) {
+            $io->success(sprintf('No shops registered on version "%s". Version can be safely removed.', $version));
+            return Command::SUCCESS;
+        }
+
+        $io->error(sprintf('"%d" shops registered on version "%s". Version cannot be removed.', count($shopIds), $version));
+
+
+        return Command::FAILURE;
+    }
+}

--- a/src/Command/UninstallVersionCommand.php
+++ b/src/Command/UninstallVersionCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Shopware\ServiceBundle\Command;
+
+use Shopware\ServiceBundle\App\AppSelector;
+use Shopware\ServiceBundle\Message\UninstallServiceFromShop;
+use Shopware\ServiceBundle\ShopRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'services:uninstall-version',
+    description: 'Attempts to uninstall the service from any shops on the given version.',
+)]
+class UninstallVersionCommand extends Command
+{
+    public function __construct(
+        private ShopRepository $repository,
+        private readonly AppSelector $appSelector,
+        private readonly MessageBusInterface $messageBus,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'version',
+            InputArgument::REQUIRED,
+            'The version to remove.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $version = $input->getArgument('version');
+        assert(is_string($version));
+
+        if (!$this->appSelector->hasVersion($version)) {
+            $io->error(sprintf('Version "%s" does not exist', $version));
+            return Command::FAILURE;
+        }
+
+        $shopIds = [];
+        foreach ($this->repository->findActiveShopsForVersion($version) as $shop) {
+            $shopIds[] = $shop->getShopId();
+        }
+
+        if (empty($shopIds)) {
+            $io->info(sprintf('No shops registered on version "%s"', $version));
+            return Command::SUCCESS;
+        }
+
+        $io->info(sprintf('Attempting to uninstall service version "%s" from "%d" shops', $version, count($shopIds)));
+        foreach ($shopIds as $shopId) {
+            $this->messageBus->dispatch(new UninstallServiceFromShop($shopId));
+        }
+
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Message/UninstallServiceFromShop.php
+++ b/src/Message/UninstallServiceFromShop.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Shopware\ServiceBundle\Message;
+
+class UninstallServiceFromShop
+{
+    public function __construct(public string $shopId) {}
+}

--- a/src/MessageHandler/UninstallServiceFromShopHandler.php
+++ b/src/MessageHandler/UninstallServiceFromShopHandler.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Shopware\ServiceBundle\MessageHandler;
+
+use Shopware\ServiceBundle\Message\UninstallServiceFromShop;
+use Shopware\ServiceBundle\Service\ShopServiceUninstaller;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+readonly class UninstallServiceFromShopHandler
+{
+    public function __construct(private ShopServiceUninstaller $shopServiceUninstaller) {}
+
+    public function __invoke(UninstallServiceFromShop $message): void
+    {
+        $this->shopServiceUninstaller->run($message->shopId);
+    }
+}

--- a/src/Service/ShopServiceUninstaller.php
+++ b/src/Service/ShopServiceUninstaller.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Shopware\ServiceBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Shopware\App\SDK\AppConfiguration;
+use Shopware\App\SDK\HttpClient\ClientFactory;
+use Shopware\App\SDK\Shop\ShopRepositoryInterface;
+use Shopware\ServiceBundle\Entity\Shop;
+
+class ShopServiceUninstaller
+{
+    /**
+     * @param ShopRepositoryInterface<Shop> $shopRepository
+     */
+    public function __construct(
+        private readonly ShopRepositoryInterface $shopRepository,
+        private readonly AppConfiguration $serviceConfiguration,
+        private readonly ClientFactory $shopHttpClientFactory,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function run(string $shopId): void
+    {
+        /** @var Shop|null $shop */
+        $shop = $this->shopRepository->getShopFromId($shopId);
+
+        if (null === $shop) {
+            throw new \RuntimeException(sprintf('Shop with id "%s" not found', $shopId));
+        }
+
+        $this->logger->info(sprintf('Uninstalling service for shop "%s"', $shop->getShopId()));
+
+        $client = $this->shopHttpClientFactory->createSimpleClient($shop);
+
+        $result = $client->post($shop->getShopUrl() . '/api/service/uninstall/' . $this->serviceConfiguration->getAppName(), []);
+
+        if ($result->ok()) {
+            $shop->setShopActive(false);
+            $shop->selectedAppVersion = null;
+            $shop->selectedAppHash = null;
+            $this->shopRepository->updateShop($shop);
+        }
+    }
+}

--- a/src/ShopRepository.php
+++ b/src/ShopRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Shopware\ServiceBundle;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Generator;
+use Shopware\ServiceBundle\Entity\Shop;
+
+class ShopRepository
+{
+    public function __construct(private readonly ManagerRegistry $registry) {}
+
+    /**
+     * @return Generator<Shop>
+     */
+    public function findAll(): Generator
+    {
+        return $this->iterate();
+    }
+
+    /**
+     * @param string $version
+     * @return Generator<Shop>
+     */
+    public function findActiveShopsForVersion(string $version): Generator
+    {
+        return $this->iterate([
+            'shopActive' => true,
+            'selectedAppVersion' => $version,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @return Generator<Shop>
+     */
+    private function iterate(array $criteria = []): Generator
+    {
+        $repository = $this->registry->getRepository(Shop::class);
+
+        $batchCount = 100;
+
+        // current offset to navigate over the entire set
+        $offset = 0;
+
+        while ($shops = $repository->findBy($criteria, null, $batchCount, $offset)) {
+            yield from $shops;
+
+            $this->registry->getManager()->clear();
+            $offset += $batchCount;
+        }
+    }
+}

--- a/tests/App/AppSelectorTest.php
+++ b/tests/App/AppSelectorTest.php
@@ -94,4 +94,13 @@ class AppSelectorTest extends TestCase
 
         static::assertSame($loader->load(), $selector->all());
     }
+
+    public function testHas(): void
+    {
+        $loader = $this->getAppLoaderMock();
+        $selector = new AppSelector($loader);
+
+        static::assertTrue($selector->hasVersion('6.6.0.0'));
+        static::assertFalse($selector->hasVersion('6.6.0.1'));
+    }
 }

--- a/tests/Command/CanCleanupVersionCommandTest.php
+++ b/tests/Command/CanCleanupVersionCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\ServiceBundle\App\App;
+use Shopware\ServiceBundle\App\AppLoader;
+use Shopware\ServiceBundle\App\AppSelector;
+use Shopware\ServiceBundle\Command\CanCleanupVersionCommand;
+use Shopware\ServiceBundle\Entity\Shop;
+use Shopware\ServiceBundle\ShopRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(CanCleanupVersionCommand::class)]
+#[CoversClass(AppSelector::class)]
+#[CoversClass(App::class)]
+class CanCleanupVersionCommandTest extends TestCase
+{
+    public function testCommandFailsIfGivenVersionDoesNotExist(): void
+    {
+        $appLoader = $this->createMock(AppLoader::class);
+        $appLoader->expects(static::once())->method('load')->willReturn([]);
+        $appSelector = new AppSelector($appLoader);
+        $repo = $this->createMock(ShopRepository::class);
+        $command = new CanCleanupVersionCommand($repo, $appSelector);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['version' => '1.0.0']);
+
+        static::assertEquals(Command::FAILURE, $commandTester->getStatusCode());
+        static::assertStringContainsString(
+            'Version "1.0.0" does not exist',
+            $commandTester->getDisplay(),
+        );
+    }
+
+    public function testCommandFailsWhenVersionsExist(): void
+    {
+        $appLoader = $this->createMock(AppLoader::class);
+        $appLoader->expects(static::any())->method('load')->willReturn([
+            new App('/', 'MyApp', '1.0.0', '1.0.0'),
+            new App('/', 'MyApp', '2.0.0', '2.0.0'),
+            new App('/', 'MyApp', '3.0.0', '3.0.0'),
+        ]);
+        $appSelector = new AppSelector($appLoader);
+        $repo = $this->createMock(ShopRepository::class);
+
+        $repo->expects(static::any())
+            ->method('findActiveShopsForVersion')
+            ->with('1.0.0')
+            ->willReturnCallback(function (): \Generator {
+                $shop = new Shop('id-1', '/', 'secret');
+                $shop->setShopActive(true);
+                $shop->selectedAppVersion = '1.0.0';
+
+                yield $shop;
+
+                $shop = new Shop('id-2', '/', 'secret');
+                $shop->setShopActive(true);
+                $shop->selectedAppVersion = '1.0.0';
+
+                yield $shop;
+            });
+
+        $command = new CanCleanupVersionCommand($repo, $appSelector);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['version' => '1.0.0']);
+
+        static::assertEquals(Command::FAILURE, $commandTester->getStatusCode());
+        static::assertStringContainsString(
+            '"2" shops registered on version "1.0.0". Version cannot be removed.',
+            $commandTester->getDisplay(),
+        );
+    }
+
+    public function testCommandPassesWhenVersionsDoNotExist(): void
+    {
+        $appLoader = $this->createMock(AppLoader::class);
+        $appLoader->expects(static::any())->method('load')->willReturn([
+            new App('/', 'MyApp', '1.0.0', '1.0.0'),
+            new App('/', 'MyApp', '2.0.0', '2.0.0'),
+            new App('/', 'MyApp', '3.0.0', '3.0.0'),
+        ]);
+        $appSelector = new AppSelector($appLoader);
+        $repo = $this->createMock(ShopRepository::class);
+
+        $repo->expects(static::any())
+            ->method('findActiveShopsForVersion')
+            ->with('3.0.0')
+            ->willReturnCallback(function (): \Generator {
+                yield from [];
+            });
+
+        $command = new CanCleanupVersionCommand($repo, $appSelector);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['version' => '3.0.0']);
+
+        $commandTester->assertCommandIsSuccessful();
+        static::assertStringContainsString(
+            'No shops registered on version "3.0.0". Version can be safely removed.',
+            $commandTester->getDisplay(),
+        );
+    }
+}

--- a/tests/Command/UninstallVersionCommandTest.php
+++ b/tests/Command/UninstallVersionCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\ServiceBundle\App\App;
+use Shopware\ServiceBundle\App\AppLoader;
+use Shopware\ServiceBundle\App\AppSelector;
+use Shopware\ServiceBundle\Command\UninstallVersionCommand;
+use Shopware\ServiceBundle\Entity\Shop;
+use Shopware\ServiceBundle\Message\UninstallServiceFromShop;
+use Shopware\ServiceBundle\ShopRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(UninstallVersionCommand::class)]
+#[CoversClass(AppSelector::class)]
+#[CoversClass(App::class)]
+#[CoversClass(UninstallServiceFromShop::class)]
+class UninstallVersionCommandTest extends TestCase
+{
+    public function testCommandFailsIfGivenVersionDoesNotExist(): void
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+
+        $appLoader = $this->createMock(AppLoader::class);
+        $appLoader->expects(static::once())->method('load')->willReturn([]);
+        $appSelector = new AppSelector($appLoader);
+        $repo = $this->createMock(ShopRepository::class);
+        $command = new UninstallVersionCommand($repo, $appSelector, $bus);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['version' => '1.0.0']);
+
+        static::assertEquals(Command::FAILURE, $commandTester->getStatusCode());
+        static::assertStringContainsString(
+            'Version "1.0.0" does not exist',
+            $commandTester->getDisplay(),
+        );
+    }
+
+    public function testUninstallVersionOnlyUninstallsActiveShopsForTheGivenVersion(): void
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $matcher = $this->exactly(2);
+
+        $bus->expects($matcher)
+            ->method('dispatch')
+            ->willReturnCallback(function (UninstallServiceFromShop $msg) use ($matcher) {
+                static::assertEquals([1 => 'id-1', 2 => 'id-2'][$matcher->numberOfInvocations()], $msg->shopId);
+                return new Envelope(new \stdClass());
+            });
+
+        $appLoader = $this->createMock(AppLoader::class);
+        $appLoader->expects(static::once())->method('load')->willReturn([
+            new App('/', 'MyApp', '1.0.0', '1.0.0'),
+            new App('/', 'MyApp', '2.0.0', '2.0.0'),
+        ]);
+        $appSelector = new AppSelector($appLoader);
+        $repo = $this->createMock(ShopRepository::class);
+        $repo->expects(static::once())
+            ->method('findActiveShopsForVersion')
+            ->with('1.0.0')
+            ->willReturnCallback(function (): \Generator {
+                $shop = new Shop('id-1', '/', 'secret');
+                $shop->setShopActive(true);
+                $shop->selectedAppVersion = '1.0.0';
+
+                yield $shop;
+
+                $shop = new Shop('id-2', '/', 'secret');
+                $shop->setShopActive(true);
+                $shop->selectedAppVersion = '1.0.0';
+
+                yield $shop;
+            });
+
+        $command = new UninstallVersionCommand($repo, $appSelector, $bus);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['version' => '1.0.0']);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        static::assertStringContainsString(
+            'Attempting to uninstall service version "1.0.0" from "2" shops',
+            $commandTester->getDisplay(),
+        );
+    }
+}

--- a/tests/Message/UninstallServiceFromShopTest.php
+++ b/tests/Message/UninstallServiceFromShopTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Shopware\ServiceBundle\Test\Message;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\ServiceBundle\Message\UninstallServiceFromShop;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(UninstallServiceFromShop::class)]
+class UninstallServiceFromShopTest extends TestCase
+{
+    public function testAccessors(): void
+    {
+        $message = new UninstallServiceFromShop('shopId');
+
+        static::assertSame('shopId', $message->shopId);
+    }
+}

--- a/tests/MessageHandler/UninstallServiceFromShopHandlerTest.php
+++ b/tests/MessageHandler/UninstallServiceFromShopHandlerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Shopware\ServiceBundle\Test\MessageHandler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\ServiceBundle\Message\UninstallServiceFromShop;
+use Shopware\ServiceBundle\MessageHandler\UninstallServiceFromShopHandler;
+use PHPUnit\Framework\TestCase;
+use Shopware\ServiceBundle\Service\ShopServiceUninstaller;
+
+#[CoversClass(UninstallServiceFromShop::class)]
+#[CoversClass(UninstallServiceFromShopHandler::class)]
+class UninstallServiceFromShopHandlerTest extends TestCase
+{
+    public function testHandlerDelegatesToService(): void
+    {
+        $updater = static::createMock(ShopServiceUninstaller::class);
+        $handler = new UninstallServiceFromShopHandler($updater);
+
+        $updater->expects(static::once())
+            ->method('run')
+            ->with('shopId');
+
+        $message = new UninstallServiceFromShop('shopId');
+        $handler->__invoke($message);
+    }
+}

--- a/tests/Service/ShopServiceUninstallerTest.php
+++ b/tests/Service/ShopServiceUninstallerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Shopware\ServiceBundle\Test\Service;
+
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\LoggerInterface;
+use Shopware\App\SDK\AppConfiguration;
+use Shopware\App\SDK\HttpClient\ClientFactory;
+use Shopware\App\SDK\HttpClient\SimpleHttpClient\SimpleHttpClient;
+use Shopware\App\SDK\HttpClient\SimpleHttpClient\SimpleHttpClientResponse;
+use Shopware\App\SDK\Shop\ShopRepositoryInterface;
+use Shopware\App\SDK\Test\MockShopRepository;
+use Shopware\ServiceBundle\Entity\Shop;
+use Shopware\ServiceBundle\Service\ShopServiceUninstaller;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ShopServiceUninstaller::class)]
+class ShopServiceUninstallerTest extends TestCase
+{
+    public function testRunThrowsExceptionWhenShopDoesNotExist(): void
+    {
+        static::expectException(\RuntimeException::class);
+        static::expectExceptionMessage('Shop with id "my-shop-id" not found');
+
+        /** @var ShopRepositoryInterface<Shop> $shopRepository */
+        $shopRepository = new MockShopRepository();
+        $clientFactory = static::createMock(ClientFactory::class);
+        $logger = static::createMock(LoggerInterface::class);
+
+        $shopUpdater = new ShopServiceUninstaller(
+            $shopRepository,
+            new AppConfiguration('MyApp', 'app-secret', '/confirm'),
+            $clientFactory,
+            $logger,
+        );
+
+        $shopUpdater->run('my-shop-id');
+    }
+
+    public function testShopIsNotDeactivatedIfUninstallFails(): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+        $shop->setShopActive(true);
+        $shop->selectedAppVersion = '6.6.0.0';
+        $shop->selectedAppHash = 'aaa';
+
+        /** @var ShopRepositoryInterface<Shop> $shopRepository */
+        $shopRepository = new MockShopRepository();
+        $shopRepository->createShop($shop);
+
+        $clientFactory = static::createMock(ClientFactory::class);
+        $logger = static::createMock(LoggerInterface::class);
+
+        $client = static::createMock(SimpleHttpClient::class);
+        $client->expects(static::once())
+            ->method('post')
+            ->with('https://shop.com/api/service/uninstall/MyApp')
+            ->willReturn(new SimpleHttpClientResponse(new Response(400)));
+
+        $clientFactory->expects(static::once())
+            ->method('createSimpleClient')
+            ->willReturn($client);
+
+        $shopUpdater = new ShopServiceUninstaller(
+            $shopRepository,
+            new AppConfiguration('MyApp', 'app-secret', '/confirm'),
+            $clientFactory,
+            $logger,
+        );
+
+        $shopUpdater->run('my-shop-id');
+
+        static::assertSame(true, $shop->isShopActive());
+        static::assertSame('6.6.0.0', $shop->selectedAppVersion);
+        static::assertSame('aaa', $shop->selectedAppHash);
+    }
+
+    public function testRunDeactivatesShopAfterUninstallation(): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+        $shop->setShopActive(true);
+        $shop->selectedAppVersion = '6.6.0.0';
+        $shop->selectedAppHash = 'aaa';
+
+        /** @var ShopRepositoryInterface<Shop> $shopRepository */
+        $shopRepository = new MockShopRepository();
+        $shopRepository->createShop($shop);
+
+        $clientFactory = static::createMock(ClientFactory::class);
+        $logger = static::createMock(LoggerInterface::class);
+
+        $client = static::createMock(SimpleHttpClient::class);
+        $client->expects(static::once())
+            ->method('post')
+            ->with('https://shop.com/api/service/uninstall/MyApp')
+            ->willReturn(new SimpleHttpClientResponse(new Response()));
+
+        $clientFactory->expects(static::once())
+            ->method('createSimpleClient')
+            ->willReturn($client);
+
+        $shopUpdater = new ShopServiceUninstaller(
+            $shopRepository,
+            new AppConfiguration('MyApp', 'app-secret', '/confirm'),
+            $clientFactory,
+            $logger,
+        );
+
+        $shopUpdater->run('my-shop-id');
+
+        static::assertSame(false, $shop->isShopActive());
+        static::assertNull($shop->selectedAppVersion);
+        static::assertNull($shop->selectedAppHash);
+    }
+}

--- a/tests/ShopRepositoryTest.php
+++ b/tests/ShopRepositoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Shopware\ServiceBundle\Test;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Shopware\ServiceBundle\Entity\Shop;
+use Shopware\ServiceBundle\ShopRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+
+#[CoversClass(ShopRepository::class)]
+class ShopRepositoryTest extends TestCase
+{
+    private ManagerRegistry $managerRegistry;
+    /**
+     * @var ObjectRepository<Shop>&MockObject
+     */
+    private ObjectRepository&MockObject $repository;
+    private EntityManagerInterface&MockObject $entityManager;
+    private ShopRepository $shopRepository;
+
+    protected function setUp(): void
+    {
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->repository = $this->createMock(ObjectRepository::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->managerRegistry->method('getRepository')->willReturn($this->repository);
+        $this->managerRegistry->method('getManager')->willReturn($this->entityManager);
+
+        $this->shopRepository = new ShopRepository($this->managerRegistry);
+    }
+
+    public function testFindAllWithMultipleBatches(): void
+    {
+        $shop1 = $this->createMock(Shop::class);
+        $shop2 = $this->createMock(Shop::class);
+        $shop3 = $this->createMock(Shop::class);
+
+        $matcher = $this->exactly(3);
+        $this->repository
+            ->expects($matcher)
+            ->method('findBy')
+            ->willReturnCallback(function () use ($matcher, $shop1, $shop2, $shop3) {
+                return match ($matcher->numberOfInvocations()) {
+                    1 => [$shop1, $shop2], // First batch
+                    2 => [$shop3],         // Second batch
+                    3 => [],               // Third call returns empty
+                    default => null,
+                };
+            });
+
+        $this->entityManager->expects($this->exactly(2))->method('clear');
+
+        $result = iterator_to_array($this->shopRepository->findAll(), false);
+
+        $this->assertCount(3, $result);
+        $this->assertSame($shop1, $result[0]);
+        $this->assertSame($shop2, $result[1]);
+        $this->assertSame($shop3, $result[2]);
+    }
+
+    public function testFindActiveShopsForVersion(): void
+    {
+        $shop1 = $this->createMock(Shop::class);
+        $shop2 = $this->createMock(Shop::class);
+        $shop3 = $this->createMock(Shop::class);
+
+        $matcher = $this->exactly(3);
+        $this->repository
+            ->expects($matcher)
+            ->method('findBy')
+            ->with([
+                'shopActive' => true,
+                'selectedAppVersion' => '1.0.0',
+            ])
+            ->willReturnCallback(function () use ($matcher, $shop1, $shop2, $shop3) {
+                return match ($matcher->numberOfInvocations()) {
+                    1 => [$shop1, $shop2], // First batch
+                    2 => [$shop3],         // Second batch
+                    3 => [],               // Third call returns empty
+                    default => null,
+                };
+            });
+
+        $this->entityManager->expects($this->exactly(2))->method('clear');
+
+        $result = iterator_to_array($this->shopRepository->findActiveShopsForVersion('1.0.0'), false);
+
+        $this->assertCount(3, $result);
+        $this->assertSame($shop1, $result[0]);
+        $this->assertSame($shop2, $result[1]);
+        $this->assertSame($shop3, $result[2]);
+    }
+}


### PR DESCRIPTION
I added two commands:

`services:uninstall-version` 

So you can run `php bin/console services:uninstall-version 6.6.2.0` to uninstall 6.6.2.0 from all active shops which have it. 

When we get a 200 back from the uninstall we mark the shop as disabled (not active) and clear its selected app version. 

`services:can-cleanup-version 6.6.2.0` 

This command will tell you if any shops are still using this version and therefore if it can be deleted.