### PR TITLE
NTR - Update get feature toogles for license info

### DIFF
--- a/src/Service/CommercialLicense.php
+++ b/src/Service/CommercialLicense.php
@@ -56,10 +56,14 @@ class CommercialLicense
         /** @var \DateTimeImmutable $exp */
         $exp = $token->claims()->get('exp');
 
+        /** @var array<string, string|int|bool> $toggles */
+        $toggles = $token->claims()->get('license-toggles') ?? [];
+
         return new LicenseInfo(
             $audience[0],
             $issuedAt,
             $exp,
+            $toggles,
         );
     }
 

--- a/src/Service/LicenseInfo.php
+++ b/src/Service/LicenseInfo.php
@@ -6,5 +6,11 @@ use DateTimeImmutable;
 
 class LicenseInfo
 {
-    public function __construct(public readonly string $licenseDomain, public readonly DateTimeImmutable $issuedAt, public readonly DateTimeImmutable $expiresAt) {}
+    /** @param array<string, string|int|bool> $toggles */
+    public function __construct(
+        public readonly string            $licenseDomain,
+        public readonly DateTimeImmutable $issuedAt,
+        public readonly DateTimeImmutable $expiresAt,
+        public readonly array             $toggles,
+    ) {}
 }

--- a/tests/Service/CommercialLicenseTest.php
+++ b/tests/Service/CommercialLicenseTest.php
@@ -24,13 +24,19 @@ class CommercialLicenseTest extends TestCase
 
         $this->assertInstanceOf(LicenseInfo::class, $info);
 
-        $this->assertEquals('localhost', $info->licenseDomain);
+        $this->assertSame('localhost', $info->licenseDomain);
 
         $expected = (new \DateTimeImmutable("2022-06-22 06:56:20"))->format('Y-m-d H:i:s');
-        $this->assertEquals($expected, $info->issuedAt->format('Y-m-d H:i:s'));
+        $this->assertSame($expected, $info->issuedAt->format('Y-m-d H:i:s'));
 
         $expected = (new \DateTimeImmutable("2999-12-31 23:00:00"))->format('Y-m-d H:i:s');
-        $this->assertEquals($expected, $info->expiresAt->format('Y-m-d H:i:s'));
+        $this->assertSame($expected, $info->expiresAt->format('Y-m-d H:i:s'));
+
+        $this->assertSame([
+            '000001' => true,
+            '000002' => false,
+            '000003' => true,
+        ], $info->toggles);
     }
 
     public function testValidateWithInvalidLicenseKey(): void


### PR DESCRIPTION
Why do we need this change?

The swag recommendations need to identify which shop plan they belong to based on the feature parser from License info.