### PR TITLE
feat: handle commercial_license.provided webhook

### DIFF
--- a/src/Controller/LicenseController.php
+++ b/src/Controller/LicenseController.php
@@ -72,8 +72,16 @@ class LicenseController
             return $this->createErrorResponse('missing_license_credentials', 'No licenseKey and licenseHost provided', Response::HTTP_BAD_REQUEST);
         }
 
-        $licenseKey = isset($payload['licenseKey']) && is_string($payload['licenseKey']) ? $payload['licenseKey'] : '';
-        $licenseHost = isset($payload['licenseHost']) && is_string($payload['licenseHost']) ? $payload['licenseHost'] : '';
+        if (isset($payload['licenseKey']) && !is_string($payload['licenseKey'])) {
+            return new Response(null, Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        if (isset($payload['licenseHost']) && !is_string($payload['licenseHost'])) {
+            return new Response(null, Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $licenseKey = $payload['licenseKey'] ?? '';
+        $licenseHost = $payload['licenseHost'] ?? '';
 
         /** @var Shop $shop */
         $shop = $request->shop;

--- a/src/Controller/LicenseController.php
+++ b/src/Controller/LicenseController.php
@@ -28,9 +28,8 @@ class LicenseController
     /**
      * @param Shop $shop
      *
-     * @deprecated tag:v6.8.0 - Replaced by the `commercial_license.provided` webhook handled by self::provided().
-     *                          The Shopware platform stops pushing to this endpoint once an app declares the
-     *                          new webhook in its manifest. See https://github.com/shopware/shopware/pull/16635.
+     * This endpoint is used until Shopware version < 6.7.11.
+     * Use the service/license/commercial/provided endpoint for Shopware version >= 6.7.11.
      */
     #[Route('/service/license/commercial/sync', name: 'service.sync.commercial-license-info', methods: ['POST'])]
     public function sync(ShopInterface $shop, Request $request): Response

--- a/src/Controller/LicenseController.php
+++ b/src/Controller/LicenseController.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\ServiceBundle\Controller;
 
+use Shopware\App\SDK\Context\Webhook\WebhookAction;
 use Shopware\App\SDK\Shop\ShopInterface;
 use Shopware\App\SDK\Shop\ShopRepositoryInterface;
 use Shopware\ServiceBundle\Entity\Shop;
@@ -26,6 +27,10 @@ class LicenseController
 
     /**
      * @param Shop $shop
+     *
+     * @deprecated tag:v6.8.0 - Replaced by the `commercial_license.provided` webhook handled by self::provided().
+     *                          The Shopware platform stops pushing to this endpoint once an app declares the
+     *                          new webhook in its manifest. See https://github.com/shopware/shopware/pull/16635.
      */
     #[Route('/service/license/commercial/sync', name: 'service.sync.commercial-license-info', methods: ['POST'])]
     public function sync(ShopInterface $shop, Request $request): Response
@@ -38,6 +43,40 @@ class LicenseController
 
         $licenseKey = is_string($payload['licenseKey'] ?? null) ? $payload['licenseKey'] : '';
         $licenseHost = is_string($payload['licenseHost'] ?? null) ? $payload['licenseHost'] : '';
+
+        if ($licenseKey !== '') {
+            try {
+                $this->commercialLicense->validate($licenseKey);
+                $shop->commercialLicenseKey = $licenseKey;
+            } catch (LicenseException $e) {
+                return $this->createErrorResponse('license_validation_failed', $e->getMessage(), Response::HTTP_FORBIDDEN);
+            }
+        }
+
+        $shop->commercialLicenseHost = $licenseHost;
+
+        try {
+            $this->shopRepository->updateShop($shop);
+        } catch (\Throwable $e) {
+            return $this->createErrorResponse('shop_update_license_failed', $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    public function provided(WebhookAction $request): Response
+    {
+        $payload = $request->payload;
+
+        if (!isset($payload['licenseKey']) && !isset($payload['licenseHost'])) {
+            return $this->createErrorResponse('missing_license_credentials', 'No licenseKey and licenseHost provided', Response::HTTP_BAD_REQUEST);
+        }
+
+        $licenseKey = isset($payload['licenseKey']) && is_string($payload['licenseKey']) ? $payload['licenseKey'] : '';
+        $licenseHost = isset($payload['licenseHost']) && is_string($payload['licenseHost']) ? $payload['licenseHost'] : '';
+
+        /** @var Shop $shop */
+        $shop = $request->shop;
 
         if ($licenseKey !== '') {
             try {

--- a/src/Controller/LicenseController.php
+++ b/src/Controller/LicenseController.php
@@ -73,11 +73,11 @@ class LicenseController
         }
 
         if (array_key_exists('licenseKey', $payload) && !is_string($payload['licenseKey'])) {
-            return new Response(null, Response::HTTP_UNPROCESSABLE_ENTITY);
+            return $this->createErrorResponse('invalid_license_payload', 'licenseKey must be a string', Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
         if (array_key_exists('licenseHost', $payload) && !is_string($payload['licenseHost'])) {
-            return new Response(null, Response::HTTP_UNPROCESSABLE_ENTITY);
+            return $this->createErrorResponse('invalid_license_payload', 'licenseHost must be a string', Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
         $licenseKey = $payload['licenseKey'] ?? '';

--- a/src/Controller/LicenseController.php
+++ b/src/Controller/LicenseController.php
@@ -68,15 +68,15 @@ class LicenseController
     {
         $payload = $request->payload;
 
-        if (!isset($payload['licenseKey']) && !isset($payload['licenseHost'])) {
+        if (!array_key_exists('licenseKey', $payload) && !array_key_exists('licenseHost', $payload)) {
             return $this->createErrorResponse('missing_license_credentials', 'No licenseKey and licenseHost provided', Response::HTTP_BAD_REQUEST);
         }
 
-        if (isset($payload['licenseKey']) && !is_string($payload['licenseKey'])) {
+        if (array_key_exists('licenseKey', $payload) && !is_string($payload['licenseKey'])) {
             return new Response(null, Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
-        if (isset($payload['licenseHost']) && !is_string($payload['licenseHost'])) {
+        if (array_key_exists('licenseHost', $payload) && !is_string($payload['licenseHost'])) {
             return new Response(null, Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 

--- a/src/Resources/config/routing/lifecycle.xml
+++ b/src/Resources/config/routing/lifecycle.xml
@@ -22,4 +22,8 @@
     <route id="shopware_service_license_sync" path="/service/license/commercial/sync" methods="POST">
         <default key="_controller">\Shopware\ServiceBundle\Controller\LicenseController::sync</default>
     </route>
+
+    <route id="shopware_service_license_provided" path="/service/license/commercial/provided" methods="POST">
+        <default key="_controller">\Shopware\ServiceBundle\Controller\LicenseController::provided</default>
+    </route>
 </routes>

--- a/tests/Controller/LicenseControllerTest.php
+++ b/tests/Controller/LicenseControllerTest.php
@@ -299,23 +299,23 @@ class LicenseControllerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{array<string, mixed>}>
+     * @return iterable<string, array{array<string, mixed>, string}>
      */
     public static function nonStringPayloadProvider(): iterable
     {
-        yield 'licenseHost is array' => [['licenseKey' => 'valid_key', 'licenseHost' => []]];
-        yield 'licenseHost is int' => [['licenseKey' => 'valid_key', 'licenseHost' => 42]];
-        yield 'licenseHost is null' => [['licenseKey' => 'valid_key', 'licenseHost' => null]];
-        yield 'licenseKey is array' => [['licenseKey' => [], 'licenseHost' => 'valid_host']];
-        yield 'licenseKey is bool' => [['licenseKey' => true, 'licenseHost' => 'valid_host']];
-        yield 'licenseKey is null' => [['licenseKey' => null, 'licenseHost' => 'valid_host']];
+        yield 'licenseHost is array' => [['licenseKey' => 'valid_key', 'licenseHost' => []], 'licenseHost must be a string'];
+        yield 'licenseHost is int' => [['licenseKey' => 'valid_key', 'licenseHost' => 42], 'licenseHost must be a string'];
+        yield 'licenseHost is null' => [['licenseKey' => 'valid_key', 'licenseHost' => null], 'licenseHost must be a string'];
+        yield 'licenseKey is array' => [['licenseKey' => [], 'licenseHost' => 'valid_host'], 'licenseKey must be a string'];
+        yield 'licenseKey is bool' => [['licenseKey' => true, 'licenseHost' => 'valid_host'], 'licenseKey must be a string'];
+        yield 'licenseKey is null' => [['licenseKey' => null, 'licenseHost' => 'valid_host'], 'licenseKey must be a string'];
     }
 
     /**
      * @param array<string, mixed> $payload
      */
     #[DataProvider('nonStringPayloadProvider')]
-    public function testProvidedReturns422OnNonStringPayloadFieldsAndDoesNotPersist(array $payload): void
+    public function testProvidedReturns422OnNonStringPayloadFieldsAndDoesNotPersist(array $payload, string $expectedDetail): void
     {
         $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
         $shop->commercialLicenseKey = 'pre-existing-key';
@@ -331,7 +331,18 @@ class LicenseControllerTest extends TestCase
 
         $response = $licenseController->provided($this->buildWebhookAction($shop, $payload));
 
+        $content = $response->getContent();
+        $this->assertIsString($content);
+        $decodedContent = json_decode($content, true);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame([
+            'errors' => [
+                'type' => 'invalid_license_payload',
+                'detail' => $expectedDetail,
+            ],
+        ], $decodedContent);
         $this->assertSame('pre-existing-key', $shop->commercialLicenseKey);
         $this->assertSame('pre-existing-host', $shop->commercialLicenseHost);
     }

--- a/tests/Controller/LicenseControllerTest.php
+++ b/tests/Controller/LicenseControllerTest.php
@@ -4,6 +4,9 @@ namespace Shopware\ServiceBundle\Test\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
+use Shopware\App\SDK\Context\ActionSource;
+use Shopware\App\SDK\Context\Webhook\WebhookAction;
+use Shopware\App\SDK\Framework\Collection;
 use Shopware\App\SDK\Shop\ShopRepositoryInterface;
 use Shopware\App\SDK\Test\MockShopRepository;
 use Shopware\ServiceBundle\Controller\LicenseController;
@@ -181,5 +184,154 @@ class LicenseControllerTest extends TestCase
                 'detail' => 'Shop with id "my-shop-id-1" not found',
             ],
         ], $decodedContent);
+    }
+
+    public function testProvidedWithValidCredentials(): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+
+        /** @var ShopRepositoryInterface<Shop>&MockObject $shopRepository */
+        $shopRepository = $this->createMock(ShopRepositoryInterface::class);
+        $shopRepository->expects($this->once())->method('updateShop')->with($shop);
+
+        $this->commercialLicense->expects($this->once())->method('validate')->with('valid_key');
+
+        $licenseController = new LicenseController($shopRepository, $this->commercialLicense);
+
+        $response = $licenseController->provided($this->buildWebhookAction($shop, [
+            'licenseKey' => 'valid_key',
+            'licenseHost' => 'valid_host',
+        ]));
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEmpty($response->getContent());
+        $this->assertSame('valid_key', $shop->commercialLicenseKey);
+        $this->assertSame('valid_host', $shop->commercialLicenseHost);
+    }
+
+    public function testProvidedWithMissingCredentialsReturns400(): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+
+        /** @var ShopRepositoryInterface<Shop>&MockObject $shopRepository */
+        $shopRepository = $this->createMock(ShopRepositoryInterface::class);
+        $shopRepository->expects($this->never())->method('updateShop');
+
+        $this->commercialLicense->expects($this->never())->method('validate');
+
+        $licenseController = new LicenseController($shopRepository, $this->commercialLicense);
+
+        $response = $licenseController->provided($this->buildWebhookAction($shop, []));
+
+        $content = $response->getContent();
+        $this->assertIsString($content);
+        $decodedContent = json_decode($content, true);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertEquals([
+            'errors' => [
+                'type' => 'missing_license_credentials',
+                'detail' => 'No licenseKey and licenseHost provided',
+            ],
+        ], $decodedContent);
+    }
+
+    public function testProvidedWithInvalidLicenseKeyReturns403AndSkipsUpdate(): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+
+        /** @var ShopRepositoryInterface<Shop>&MockObject $shopRepository */
+        $shopRepository = $this->createMock(ShopRepositoryInterface::class);
+        $shopRepository->expects($this->never())->method('updateShop');
+
+        $this->commercialLicense->method('validate')
+            ->willThrowException(LicenseException::licenseInvalid('invalid_key'));
+
+        $licenseController = new LicenseController($shopRepository, $this->commercialLicense);
+
+        $response = $licenseController->provided($this->buildWebhookAction($shop, [
+            'licenseKey' => 'invalid_key',
+            'licenseHost' => 'valid_host',
+        ]));
+
+        $dataExpected = [
+            'errors' => [
+                'type' => 'license_validation_failed',
+                'detail' => 'License key not valid: invalid_key',
+            ],
+        ];
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertEquals(json_encode($dataExpected), $response->getContent());
+    }
+
+    public function testProvidedWithShopUpdateFailureReturns500(): void
+    {
+        $shop = new Shop('my-shop-id-1', 'https://shop.com', 'secret');
+
+        /** @var ShopRepositoryInterface<Shop> $shopRepository */
+        $shopRepository = new MockShopServiceRepository();
+
+        $this->commercialLicense->expects($this->once())->method('validate')->with('valid_key');
+
+        $licenseController = new LicenseController($shopRepository, $this->commercialLicense);
+
+        $response = $licenseController->provided($this->buildWebhookAction($shop, [
+            'licenseKey' => 'valid_key',
+            'licenseHost' => 'valid_host',
+        ]));
+
+        $content = $response->getContent();
+        $this->assertIsString($content);
+        $decodedContent = json_decode($content, true);
+
+        $this->assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertEquals([
+            'errors' => [
+                'type' => 'shop_update_license_failed',
+                'detail' => 'Shop with id "my-shop-id-1" not found',
+            ],
+        ], $decodedContent);
+    }
+
+    public function testProvidedWithHostOnlyDoesNotValidateAndPersists(): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+        $shop->commercialLicenseKey = 'pre-existing-key';
+
+        /** @var ShopRepositoryInterface<Shop>&MockObject $shopRepository */
+        $shopRepository = $this->createMock(ShopRepositoryInterface::class);
+        $shopRepository->expects($this->once())->method('updateShop')->with($shop);
+
+        $this->commercialLicense->expects($this->never())->method('validate');
+
+        $licenseController = new LicenseController($shopRepository, $this->commercialLicense);
+
+        $response = $licenseController->provided($this->buildWebhookAction($shop, [
+            'licenseKey' => '',
+            'licenseHost' => 'valid_host',
+        ]));
+
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEmpty($response->getContent());
+        $this->assertSame('pre-existing-key', $shop->commercialLicenseKey);
+        $this->assertSame('valid_host', $shop->commercialLicenseHost);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function buildWebhookAction(Shop $shop, array $payload): WebhookAction
+    {
+        return new WebhookAction(
+            $shop,
+            new ActionSource('https://shop.com', '6.7.11', new Collection()),
+            'commercial_license.provided',
+            $payload,
+            new \DateTimeImmutable(),
+        );
     }
 }

--- a/tests/Controller/LicenseControllerTest.php
+++ b/tests/Controller/LicenseControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\ServiceBundle\Test\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Shopware\App\SDK\Context\ActionSource;
 use Shopware\App\SDK\Context\Webhook\WebhookAction;
@@ -295,6 +296,42 @@ class LicenseControllerTest extends TestCase
                 'detail' => 'Shop with id "my-shop-id-1" not found',
             ],
         ], $decodedContent);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function nonStringPayloadProvider(): iterable
+    {
+        yield 'licenseHost is array' => [['licenseKey' => 'valid_key', 'licenseHost' => []]];
+        yield 'licenseHost is int' => [['licenseKey' => 'valid_key', 'licenseHost' => 42]];
+        yield 'licenseKey is array' => [['licenseKey' => [], 'licenseHost' => 'valid_host']];
+        yield 'licenseKey is bool' => [['licenseKey' => true, 'licenseHost' => 'valid_host']];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('nonStringPayloadProvider')]
+    public function testProvidedReturns422OnNonStringPayloadFieldsAndDoesNotPersist(array $payload): void
+    {
+        $shop = new Shop('my-shop-id', 'https://shop.com', 'secret');
+        $shop->commercialLicenseKey = 'pre-existing-key';
+        $shop->commercialLicenseHost = 'pre-existing-host';
+
+        /** @var ShopRepositoryInterface<Shop>&MockObject $shopRepository */
+        $shopRepository = $this->createMock(ShopRepositoryInterface::class);
+        $shopRepository->expects($this->never())->method('updateShop');
+
+        $this->commercialLicense->expects($this->never())->method('validate');
+
+        $licenseController = new LicenseController($shopRepository, $this->commercialLicense);
+
+        $response = $licenseController->provided($this->buildWebhookAction($shop, $payload));
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('pre-existing-key', $shop->commercialLicenseKey);
+        $this->assertSame('pre-existing-host', $shop->commercialLicenseHost);
     }
 
     public function testProvidedWithHostOnlyDoesNotValidateAndPersists(): void

--- a/tests/Controller/LicenseControllerTest.php
+++ b/tests/Controller/LicenseControllerTest.php
@@ -305,8 +305,10 @@ class LicenseControllerTest extends TestCase
     {
         yield 'licenseHost is array' => [['licenseKey' => 'valid_key', 'licenseHost' => []]];
         yield 'licenseHost is int' => [['licenseKey' => 'valid_key', 'licenseHost' => 42]];
+        yield 'licenseHost is null' => [['licenseKey' => 'valid_key', 'licenseHost' => null]];
         yield 'licenseKey is array' => [['licenseKey' => [], 'licenseHost' => 'valid_host']];
         yield 'licenseKey is bool' => [['licenseKey' => true, 'licenseHost' => 'valid_host']];
+        yield 'licenseKey is null' => [['licenseKey' => null, 'licenseHost' => 'valid_host']];
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a handler in this bundle for the new **`commercial_license.provided`** webhook introduced upstream in shopware/shopware#16635 (target Shopware **6.7.11**). The platform fires this event when a self-managed service app is activated or when the license config changes, with payload `{licenseKey, licenseHost}`. The bundle is the natural home for the handler because it already owns the `commercialLicenseKey` / `commercialLicenseHost` columns on `Shop`, the `CommercialLicense::validate()` service, and the legacy sync route — keeping the new behaviour here means every downstream service gets it for free.

- New action `LicenseController::provided(WebhookAction $request)` — same write-effects as `sync()` (key validated only when non-empty; host always assigned), plus stricter payload validation than `sync()`.
- New XML route `shopware_service_license_provided` → `POST /service/license/commercial/provided` in `src/Resources/config/routing/lifecycle.xml`.
- Legacy `sync()` marked `@deprecated tag:v6.8.0` (text mirrored from the platform); **not removed** — older platforms still call it, and the platform itself only skips it for apps whose manifest declares the new webhook.

### Response contract for `POST /service/license/commercial/provided`

| Status | `errors.type` | When |
| --- | --- | --- |
| `204` | _(no body)_ | Success — shop updated. |
| `400` | `missing_license_credentials` | Neither `licenseKey` nor `licenseHost` present in payload. |
| `403` | `license_validation_failed` | Non-empty `licenseKey` failed `CommercialLicense::validate()`. |
| `422` | `invalid_license_payload` | `licenseKey` or `licenseHost` present but not a string (incl. `null`, `[]`, ints, bools). `detail` names the offending field. |
| `500` | `shop_update_license_failed` | `ShopRepositoryInterface::updateShop()` threw. |

The 422 case is new vs. the legacy `sync()` endpoint — added in response to review to prevent malformed payloads from silently clearing existing license state via `$shop->commercialLicenseHost = ''`. Field presence is checked with `array_key_exists()` so explicit `null` is rejected the same as any other non-string.

## Consumer integration

Each downstream service that wants this behaviour must declare the webhook in its manifest:

```xml
<webhook name="commercialLicenseProvided" url="{{APP_URL}}/service/license/commercial/provided" event="commercial_license.provided"/>
```

That change is **out of scope** here — bundle-only PR.

## Open question for reviewers

The upstream platform code's deprecation tag on the legacy endpoint is **`tag:v6.8.0`**, which is what I used in the `@deprecated` docblock. Please confirm that is the intended removal target before any consumer relies on it.

## Test plan

- [x] `vendor/bin/phpunit` → 80/80 passing (17/17 `LicenseControllerTest` cases — 11 for `provided()` covering happy path, missing credentials, invalid key, persist failure, host-only update, and 6 data-provider cases for the 422 path: `licenseKey`/`licenseHost` as array / int / bool / null).
- [x] `php-cs-fixer fix --dry-run` (with `PHP_CS_FIXER_IGNORE_ENV=1` because local PHP is 8.5) → 0 files to fix.
- [x] `phpstan analyse` on the changed files → no new errors. The only remaining warnings (`CoversClass not repeatable`) are pre-existing on `master` and present across many test files.
- [ ] Manual smoke against a consumer service after merging into a release — wiring confirmed by consumer-side manifest update.

## References

- Upstream platform PR: shopware/shopware#16635
- Event class: `Shopware\Core\Service\Event\CommercialLicenseProvidedEvent` (`NAME = 'commercial_license.provided'`)
- Subscriber dispatching: `Shopware\Core\Service\Subscriber\LicenseSyncSubscriber`